### PR TITLE
Show cursor in code blocks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,8 +24,8 @@ It differs from MarkdownFootnotes by:
 
 ## Example
 
-```
-This is a test paragraph
+```bat
+This is a test paragraph|
 
 And here is another[^chapter1-1]
 
@@ -34,12 +34,12 @@ And here is another[^chapter1-1]
 
 With the cursor at the end of the first line, hitting the shortcut produces this:
 
-```
+```bat
 This is a test paragraph[^chapter1-1]
 
 And here is another[^chapter1-2]
 
-[^chapter1-1]: 
+[^chapter1-1]: |
 
 [^chapter1-2]: Totally a footnote
 ```


### PR DESCRIPTION
The idea is that you can see the cursor easily if you do `bat` file highlighting, because a pipe `|` is a highlighted character in batch files.

If you don't like the look of this change, feel free to close the PR.