### PR TITLE
Fix Windows

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,4 +1,4 @@
-from FootnoteFunctions import insert_footnote, find_enclosing_footnote_id, find_footnote_marker_position, get_footnote_marker_id_at_position, get_footnote_body_position
+from .FootnoteFunctions import insert_footnote, find_enclosing_footnote_id, find_footnote_marker_position, get_footnote_marker_id_at_position, get_footnote_body_position
 
 def assert_equal(actual, expected):
 	if expected != actual:


### PR DESCRIPTION
Use the [dot syntax](https://stackoverflow.com/questions/7279810/what-does-a-in-an-import-statement-in-python-mean) when importing `FootnoteFunctions` from `test.py`.

Fixes #1. (I'm pretty sure it will, at least!)

![image](https://user-images.githubusercontent.com/1833684/47694383-75713e80-dbcb-11e8-9845-cd6860fef48a.png)
