### PR TITLE
Improve the tests' error messages by showing a diff

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,8 +1,16 @@
+from difflib import Differ
 from FootnoteFunctions import insert_footnote, find_enclosing_footnote_id, find_footnote_marker_position, get_footnote_marker_id_at_position, get_footnote_body_position
+
+def pretty_diff(actual, expected):
+	lines = Differ().compare(
+		actual.splitlines(keepends=True),
+		expected.splitlines(keepends=True)
+	)
+	return ''.join(lines)
 
 def assert_equal(actual, expected):
 	if expected != actual:
-		raise AssertionError('Expected: "' + str(expected) + '"\nbut got: "' + str(actual) + '"')
+		raise AssertionError(pretty_diff(actual, expected))
 
 test_string = """
 what's going on then[^ch1-1]


### PR DESCRIPTION
With this test:
```py
assert_equal("""first
second
third""", """first
second
fourth
third""")
```

Output before
```
Traceback (most recent call last):
  File "C:\Users\Joseph\Github\Sublime-AlphanumericMarkdownFootnote\test.py", line 18, in <module>
    assert_equal("""first
  File "C:\Users\Joseph\Github\Sublime-AlphanumericMarkdownFootnote\test.py", line 14, in assert_equal
    raise AssertionError('Expected: "' + str(expected) + '"\nbut got: "' + str(actual) + '"')
AssertionError: Expected: "first
second
fourth
third"
but got: "first
second
third"
```

Output after

```
Traceback (most recent call last):
  File "C:\Users\Joseph\Github\Sublime-AlphanumericMarkdownFootnote\test.py", line 16, in <module>
    assert_equal("""first
  File "C:\Users\Joseph\Github\Sublime-AlphanumericMarkdownFootnote\test.py", line 13, in assert_equal
    raise AssertionError(pretty_diff(actual, expected))
AssertionError:   first
  second
+ fourth
  third
```