### PR TITLE
Fix behavior when there is not a trailing newline

### DIFF
--- a/FootnoteFunctions.py
+++ b/FootnoteFunctions.py
@@ -119,6 +119,7 @@ def increment_footnotes_gte(string, number):
 	return string
 
 def get_footnote_body_regex_string(identifier_position_regex):
+	return r'\[\^' + identifier_position_regex + r'\]:.*(?:(?:[ \t].*(?:\n|$))|(?:\n|$))+'
 	return r'\[\^' + identifier_position_regex + r'\]:.*(?:(?:[ \t].*\n)|\n)+'
 
 def get_new_footnote_body_position(string, previous_footnote_id, position):

--- a/test.py
+++ b/test.py
@@ -828,6 +828,22 @@ assert_equal(find_footnote_marker_position(test_file2, '0-44'), 3023)
 assert_equal(get_footnote_body_position(test_file2, '0-44'), 4193)
 
 
+# no trailing whitespace
+assert_equal(insert_footnote("""
+This is a test paragraph
+
+And here is another[^chapter1-1]
+
+[^chapter1-1]:""", 25)['body'], """
+This is a test paragraph[^chapter1-1]
+
+And here is another[^chapter1-2]
+
+[^chapter1-1]: 
+
+[^chapter1-2]:""")
+
+
 # no trailing newline
 assert_equal(insert_footnote("""
 This is a test paragraph
@@ -840,6 +856,7 @@ This is a test paragraph[^chapter1-1]
 And here is another[^chapter1-2]
 
 [^chapter1-1]: 
+
 [^chapter1-2]: Totally a footnote""")
 
 

--- a/test.py
+++ b/test.py
@@ -828,4 +828,19 @@ assert_equal(find_footnote_marker_position(test_file2, '0-44'), 3023)
 assert_equal(get_footnote_body_position(test_file2, '0-44'), 4193)
 
 
+# no trailing newline
+assert_equal(insert_footnote("""
+This is a test paragraph
+
+And here is another[^chapter1-1]
+
+[^chapter1-1]: Totally a footnote""", 25)['body'], """
+This is a test paragraph[^chapter1-1]
+
+And here is another[^chapter1-2]
+
+[^chapter1-1]: 
+[^chapter1-2]: Totally a footnote""")
+
+
 print('Passing!')


### PR DESCRIPTION
I replaced both instances of `\n` in a regex with `(?:\n|$)` which is a non-capturing group that matches either a newline or the end of the string.

Fixed #6 